### PR TITLE
Add support for a separate SMTP username in email configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ You can configure the application to automatically send generated EPUBs via emai
 
 - **Gmail Configuration:** Tested with `smtp.gmail.com` on port `587`.
 - **App Password:** If using Gmail, you must use an **App Password** (your regular password will not work).
+- **SMTP Username:** Can be configured separately from the sender email address. If left empty, RSSPub falls back to the sender email address.
 - **Recommendation:** It is recommended to use a **temporary or dedicated email account** for this feature, rather than your primary personal account.
 
 ### Configuration

--- a/src/db/migration.rs
+++ b/src/db/migration.rs
@@ -88,3 +88,22 @@ pub fn migrate_general_config_cover_date(conn: &Connection) -> Result<(), Error>
     }
     Ok(())
 }
+
+pub fn migrate_email_config_smtp_username(conn: &Connection) -> Result<(), Error> {
+    let count: i32 = conn
+        .query_row(
+            "SELECT count(*) FROM pragma_table_info('email_config') WHERE name='smtp_username'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap_or(0);
+
+    if count == 0 {
+        conn.execute(
+            "ALTER TABLE email_config ADD COLUMN smtp_username TEXT NOT NULL DEFAULT ''",
+            [],
+        )?;
+    }
+
+    Ok(())
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -42,16 +42,17 @@ pub fn delete_schedule(conn: &Connection, id: i64) -> Result<()> {
 
 pub fn get_email_config(conn: &Connection) -> Result<Option<EmailConfig>> {
     let mut stmt = conn.prepare(
-        "SELECT smtp_host, smtp_port, smtp_password, email_address, to_email, enable_auto_send FROM email_config WHERE id = 1",
+        "SELECT smtp_host, smtp_port, smtp_password, smtp_username, email_address, to_email, enable_auto_send FROM email_config WHERE id = 1",
     )?;
     let mut config_iter = stmt.query_map([], |row| {
         Ok(EmailConfig {
             smtp_host: row.get(0)?,
             smtp_port: row.get(1)?,
             smtp_password: row.get(2)?,
-            email_address: row.get(3)?,
-            to_email: row.get(4)?,
-            enable_auto_send: row.get(5).unwrap_or(false),
+            smtp_username: row.get(3).unwrap_or_default(),
+            email_address: row.get(4)?,
+            to_email: row.get(5)?,
+            enable_auto_send: row.get(6).unwrap_or(false),
         })
     })?;
 
@@ -64,12 +65,13 @@ pub fn get_email_config(conn: &Connection) -> Result<Option<EmailConfig>> {
 
 pub fn save_email_config(conn: &Connection, config: &EmailConfig) -> Result<()> {
     conn.execute(
-        "INSERT OR REPLACE INTO email_config (id, smtp_host, smtp_port, smtp_password, email_address, to_email, enable_auto_send)
-         VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6)",
+        "INSERT OR REPLACE INTO email_config (id, smtp_host, smtp_port, smtp_password, smtp_username, email_address, to_email, enable_auto_send)
+         VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7)",
         params![
             config.smtp_host,
             config.smtp_port,
             config.smtp_password,
+            config.smtp_username,
             config.email_address,
             config.to_email,
             config.enable_auto_send
@@ -265,4 +267,3 @@ mod tests {
         assert_eq!(fetched_config_2.cover_date_color, "white".to_string());
     }
 }
-

--- a/src/db/schema_init.rs
+++ b/src/db/schema_init.rs
@@ -70,6 +70,7 @@ pub fn init_db(path: &str) -> rusqlite::Result<Connection> {
             smtp_host TEXT NOT NULL,
             smtp_port INTEGER NOT NULL,
             smtp_password TEXT NOT NULL,
+            smtp_username TEXT NOT NULL DEFAULT '',
             email_address TEXT NOT NULL,
             to_email TEXT NOT NULL,
             enable_auto_send BOOLEAN NOT NULL DEFAULT 0
@@ -122,5 +123,6 @@ pub fn init_db(path: &str) -> rusqlite::Result<Connection> {
     migration::migrate_position(&conn)?;
     migration::migrate_feed_schedule(&conn)?;
     migration::migrate_general_config_cover_date(&conn)?;
+    migration::migrate_email_config_smtp_username(&conn)?;
     Ok(conn)
 }

--- a/src/email.rs
+++ b/src/email.rs
@@ -17,6 +17,12 @@ use crate::db;
 pub async fn send_epub(config: &EmailConfig, epub_path: &Path) -> Result<()> {
     info!("Preparing to send email to {}", config.to_email);
 
+    let smtp_username = if config.smtp_username.trim().is_empty() {
+        config.email_address.as_str()
+    } else {
+        config.smtp_username.as_str()
+    };
+
     let filename = epub_path
         .file_name()
         .and_then(|s| s.to_str())
@@ -47,7 +53,7 @@ pub async fn send_epub(config: &EmailConfig, epub_path: &Path) -> Result<()> {
         )
         .context("Failed to build email")?;
 
-    let creds = Credentials::new(config.email_address.clone(), config.smtp_password.clone());
+    let creds = Credentials::new(smtp_username.to_string(), config.smtp_password.clone());
 
     info!(
         "Sending email via {}:{}...",

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -69,6 +69,8 @@ pub struct EmailConfig {
     pub smtp_port: u16,
     pub smtp_password: String,
     pub email_address: String,
+    #[serde(default)]
+    pub smtp_username: String,
     pub to_email: String,
     #[serde(default)]
     pub enable_auto_send: bool,

--- a/ui/src/components/EmailConfigSection.svelte
+++ b/ui/src/components/EmailConfigSection.svelte
@@ -4,6 +4,7 @@
 
     let smtp_host = "";
     let smtp_port: number | null = null;
+    let smtp_username = "";
     let smtp_password = "";
     let email_address = "";
     let to_email = "";
@@ -24,6 +25,7 @@
                 smtp_host = config.smtp_host || "";
                 smtp_port = config.smtp_port || null;
 
+                smtp_username = config.smtp_username || "";
                 smtp_password = config.smtp_password || "";
                 email_address = config.email_address || "";
                 to_email = config.to_email || "";
@@ -43,7 +45,7 @@
             await api("/email-config", "POST", {
                 smtp_host,
                 smtp_port: smtp_port || 0,
-                smtp_username: email_address,
+                smtp_username,
                 smtp_password,
                 email_address,
                 to_email,
@@ -108,6 +110,11 @@
                     bind:value={smtp_port}
                     placeholder="Port (e.g. 587)"
                     required
+                />
+                <input
+                    type="text"
+                    bind:value={smtp_username}
+                    placeholder="SMTP Username (optional)"
                 />
                 <input
                     type="password"


### PR DESCRIPTION
## Summary

This PR adds support for configuring an SMTP username independently from the sender email address.

Previously, the application reused the email address as the SMTP username. With this change, users can now provide a dedicated SMTP username when their mail provider requires credentials that differ from the sender address.

## Why

Some SMTP providers require a login username that is different from the visible sender email address. This change makes the email configuration more flexible while preserving the current behavior for existing users.

## Changes

- added a new `smtp_username` field to the email configuration model
- updated the database schema to store `smtp_username`
- added a migration for existing installations to safely introduce the new column
- updated email config persistence and retrieval to include the new field
- changed the email sending logic to use `smtp_username` for authentication
- kept backward compatibility by falling back to `email_address` when `smtp_username` is empty
- updated the UI to allow entering an optional SMTP username
- fixed the frontend payload so `smtp_username` is sent as its own value instead of always mirroring `email_address`

## Compatibility

- existing configs remain compatible
- if no SMTP username is provided, the system continues to use `email_address` as before