### PR TITLE
Improve email deliverability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -933,9 +933,9 @@ dependencies = [
 
 [[package]]
 name = "epub-builder"
-version = "0.8.3"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8598e641a211c4e43dbef0872e7fa2455c739d6eabd3456967b47a7f8923cb49"
+checksum = "94e94381ac1e9ec44be90478a25ee8e115516d65a9d8ecb46043cc0be18cd965"
 dependencies = [
  "chrono",
  "html-escape",
@@ -981,7 +981,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2100,7 +2100,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2899,7 +2899,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2958,7 +2958,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3237,7 +3237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3399,7 +3399,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4122,7 +4122,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 feed-rs = "2.3.1"
 reqwest = { version = "0.13.2", features = ["json", "blocking", "cookies", "rustls", "charset"],default-features = false }
 tokio = { version = "1.51", features = ["full"] }
-epub-builder = "0.8.3"
+epub-builder = "0.8.2"
 chrono = { version = "0.4.44", features = ["serde"] }
 chrono-tz = { version = "0.10.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/src/email.rs
+++ b/src/email.rs
@@ -6,6 +6,7 @@ use lettre::transport::smtp::authentication::Credentials;
 use lettre::AsyncSmtpTransport;
 use lettre::Tokio1Executor;
 use lettre::{AsyncTransport, Message};
+use std::env;
 use std::fs;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
@@ -13,27 +14,16 @@ use std::time::Duration;
 use tracing::{error, info};
 use rusqlite::Connection;
 use crate::db;
+use uuid::Uuid;
 
-pub async fn send_epub(config: &EmailConfig, epub_path: &Path) -> Result<()> {
-    info!("Preparing to send email to {}", config.to_email);
-
-    let smtp_username = if config.smtp_username.trim().is_empty() {
-        config.email_address.as_str()
-    } else {
-        config.smtp_username.as_str()
-    };
-
-    let filename = epub_path
-        .file_name()
-        .and_then(|s| s.to_str())
-        .unwrap_or("digest.epub");
-
-    let filebody = fs::read(epub_path).context("Failed to read EPUB file")?;
+fn build_epub_message(config: &EmailConfig, filename: &str, filebody: Vec<u8>) -> Result<Message> {
     let content_type = ContentType::parse("application/epub+zip").unwrap();
-
     let attachment = Attachment::new(String::from(filename)).body(filebody, content_type);
 
-    let email = Message::builder()
+    Message::builder()
+        .date_now()
+        .message_id(None)
+        .user_agent(format!("RSSPub/{}", env!("CARGO_PKG_VERSION")))
         .from(
             config
                 .email_address
@@ -51,7 +41,38 @@ pub async fn send_epub(config: &EmailConfig, epub_path: &Path) -> Result<()> {
                 )
                 .singlepart(attachment),
         )
-        .context("Failed to build email")?;
+        .context("Failed to build email")
+}
+
+fn debug_dump_email(email: &Message) {
+    if env::var_os("RSSPUB_DEBUG_EMAIL_DUMP").as_deref() != Some("1".as_ref()) {
+        return;
+    }
+
+    let dump_path = env::temp_dir().join(format!("rsspub-email-{}.eml", Uuid::new_v4()));
+    match fs::write(&dump_path, email.formatted()) {
+        Ok(()) => info!("Wrote debug email dump to {}", dump_path.display()),
+        Err(err) => error!("Failed to write debug email dump: {}", err),
+    }
+}
+
+pub async fn send_epub(config: &EmailConfig, epub_path: &Path) -> Result<()> {
+    info!("Preparing to send email to {}", config.to_email);
+
+    let smtp_username = if config.smtp_username.trim().is_empty() {
+        config.email_address.as_str()
+    } else {
+        config.smtp_username.as_str()
+    };
+
+    let filename = epub_path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("digest.epub");
+
+    let filebody = fs::read(epub_path).context("Failed to read EPUB file")?;
+    let email = build_epub_message(config, filename, filebody)?;
+    debug_dump_email(&email);
 
     let creds = Credentials::new(smtp_username.to_string(), config.smtp_password.clone());
 
@@ -108,4 +129,60 @@ pub async fn check_and_send_email(db: Arc<Mutex<Connection>>, filename: &String)
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_epub_message;
+    use crate::models::EmailConfig;
+
+    fn test_email_config() -> EmailConfig {
+        EmailConfig {
+            smtp_host: "smtp.example.com".to_string(),
+            smtp_port: 587,
+            smtp_password: "secret".to_string(),
+            email_address: "sender@example.com".to_string(),
+            smtp_username: "sender@example.com".to_string(),
+            to_email: "kindle@example.com".to_string(),
+            enable_auto_send: false,
+        }
+    }
+
+    #[test]
+    fn serializes_kindle_friendly_epub_email_headers() {
+        let email = build_epub_message(
+            &test_email_config(),
+            "digest.epub",
+            b"dummy epub bytes".to_vec(),
+        )
+        .expect("message should build");
+
+        let raw = String::from_utf8(email.formatted()).expect("message should serialize as utf-8");
+
+        assert!(raw.contains("Date:"), "raw message should include Date header");
+        assert!(
+            raw.contains("Message-ID:"),
+            "raw message should include Message-ID header"
+        );
+        assert!(
+            raw.contains(&format!("User-Agent: RSSPub/{}", env!("CARGO_PKG_VERSION"))),
+            "raw message should include RSSPub user agent"
+        );
+        assert!(
+            raw.contains("MIME-Version: 1.0"),
+            "raw message should include MIME-Version header"
+        );
+        assert!(
+            raw.contains("Content-Type: multipart/mixed"),
+            "raw message should be multipart/mixed"
+        );
+        assert!(
+            raw.contains("filename=\"digest.epub\"") || raw.contains("filename=digest.epub"),
+            "raw message should include attachment filename"
+        );
+        assert!(
+            raw.contains("application/epub+zip"),
+            "raw message should include EPUB content type"
+        );
+    }
 }

--- a/src/epub_gen.rs
+++ b/src/epub_gen.rs
@@ -8,6 +8,7 @@ use askama::Template;
 use chrono::Utc;
 use epub_builder::{EpubBuilder, EpubContent, EpubVersion, ReferenceType, ZipLibrary};
 use indicatif::{ProgressBar, ProgressStyle};
+use std::env;
 use std::io::{Cursor, Seek, SeekFrom, Write};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -16,6 +17,19 @@ use rusqlite::Connection;
 use ab_glyph::{point, Font, FontRef, PxScale, ScaleFont};
 use tokio::task::JoinSet;
 use tracing::info;
+
+const EPUB_LANGUAGE_ENV: &str = "RSSPUB_EPUB_LANGUAGE";
+
+fn resolve_epub_language(value: Option<String>) -> String {
+    value
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "en".to_string())
+}
+
+fn epub_language() -> String {
+    resolve_epub_language(env::var(EPUB_LANGUAGE_ENV).ok())
+}
 
 pub async fn generate_epub_data<W: Write + Seek + Send + 'static>(
     articles: &[Article],
@@ -83,6 +97,9 @@ pub async fn generate_epub_data<W: Write + Seek + Send + 'static>(
         builder.epub_version(EpubVersion::V33);
         builder
             .metadata("author", "RSSPub RSS Book")
+            .map_err(|e| anyhow::anyhow!("{}", e))?;
+        builder
+            .metadata("lang", epub_language())
             .map_err(|e| anyhow::anyhow!("{}", e))?;
         builder
             .metadata(
@@ -331,6 +348,26 @@ pub async fn generate_epub_data<W: Write + Seek + Send + 'static>(
 
     info!("EPUB generated successfully");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_epub_language;
+
+    #[test]
+    fn uses_default_epub_language_when_env_missing() {
+        assert_eq!(resolve_epub_language(None), "en");
+    }
+
+    #[test]
+    fn trims_configured_epub_language() {
+        assert_eq!(resolve_epub_language(Some(" de ".to_string())), "de");
+    }
+
+    #[test]
+    fn ignores_empty_configured_epub_language() {
+        assert_eq!(resolve_epub_language(Some("   ".to_string())), "en");
+    }
 }
 
 fn generate_cover_image(cover_data: &Vec<u8>) -> Vec<u8> {

--- a/tests/epub_gen_tests.rs
+++ b/tests/epub_gen_tests.rs
@@ -315,6 +315,20 @@ async fn test_article_metadata_formatting() {
     assert!(chapter.contains("Back to Feed TOC"), "Should have back to TOC link");
 }
 
+#[tokio::test]
+async fn test_content_opf_includes_language_metadata() {
+    let articles = vec![create_simple_article("Language Test", "Metadata Source", 0)];
+
+    let epub_data = generate_epub_to_vec(&articles).await;
+    let mut archive = extract_epub(epub_data);
+    let content_opf = read_epub_file(&mut archive, "content.opf").unwrap();
+
+    assert!(
+        content_opf.contains("<dc:language") && content_opf.contains(">en</dc:language>"),
+        "content.opf should include dc:language metadata"
+    );
+}
+
 // ============================================================================
 // Sequencing and Ordering Tests
 // ============================================================================


### PR DESCRIPTION
## Summary
- Explicitly set Date, Message-ID, and User-Agent headers on outgoing EPUB emails to make RSSPub-generated messages look more like standard mail client output.
- Add an optional dump for local email diagnostics with `RSSPUB_DEBUG_EMAIL_DUMP=1`
- Explicitly set the EPUB language metadata, configurable via RSSPUB_EPUB_LANGUAGE and defaulting to en, so generated content.opf files include the required dc:language element.
- Downgrade epub-builder from 0.8.3 to 0.8.2 because we first hit EPUB validation failures from a missing dc:language, and after fixing that, 0.8.3 exposed a second issue by generating duplicate OPF IDs for dc:language and dc:creator, which breaks validation and can cause Kindle delivery failures.

## Why
This improves the compatibility of RSSPub-generated emails with stricter mail consumers such as Send to Kindle. While the existing messages were mostly valid, they were missing standard client-like headers such as Date and Message-ID, which can make automatically generated emails look less trustworthy than messages sent by regular mail clients. By explicitly setting these headers, the generated emails become more standards-compliant, easier to debug, and closer to the format produced by real email clients.