### PR TITLE
Feature Suggestion: Extend schedules with multiple categories and email

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ vncmain.sh
 /static/ebo.svg
 /static/icons
 .env
+.vite

--- a/src/db/migration.rs
+++ b/src/db/migration.rs
@@ -48,7 +48,6 @@ pub fn migrate_position(conn: &Connection) -> Result<(), Error> {
 }
 
 pub fn migrate_feed_schedule(conn: &Connection) -> Result<(), Error> {
-
     let count_category_id: i32 = conn
         .query_row(
             "SELECT count(*) FROM pragma_table_info('schedules') WHERE name='category_id'",
@@ -58,11 +57,91 @@ pub fn migrate_feed_schedule(conn: &Connection) -> Result<(), Error> {
         .unwrap_or(0);
 
     if count_category_id == 0 {
+        conn.execute("ALTER TABLE schedules ADD COLUMN category_id INTEGER", [])?;
+    }
+
+    Ok(())
+}
+
+pub fn migrate_schedule_timezone(conn: &Connection) -> Result<(), Error> {
+    let count: i32 = conn
+        .query_row(
+            "SELECT count(*) FROM pragma_table_info('schedules') WHERE name='timezone'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap_or(0);
+
+    if count == 0 {
         conn.execute(
-            "ALTER TABLE schedules ADD COLUMN category_id INTEGER",
+            "ALTER TABLE schedules ADD COLUMN timezone TEXT NOT NULL DEFAULT 'UTC'",
             [],
         )?;
     }
+
+    Ok(())
+}
+
+pub fn migrate_schedule_email_override(conn: &Connection) -> Result<(), Error> {
+    let count: i32 = conn
+        .query_row(
+            "SELECT count(*) FROM pragma_table_info('schedules') WHERE name='override_to_email'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap_or(0);
+
+    if count == 0 {
+        conn.execute(
+            "ALTER TABLE schedules ADD COLUMN override_to_email TEXT",
+            [],
+        )?;
+    }
+
+    Ok(())
+}
+
+pub fn migrate_schedule_fetch_since_hours_override(conn: &Connection) -> Result<(), Error> {
+    let count: i32 = conn
+        .query_row(
+            "SELECT count(*) FROM pragma_table_info('schedules') WHERE name='fetch_since_hours_override'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap_or(0);
+
+    if count == 0 {
+        conn.execute(
+            "ALTER TABLE schedules ADD COLUMN fetch_since_hours_override INTEGER",
+            [],
+        )?;
+    }
+
+    Ok(())
+}
+
+pub fn migrate_schedule_categories(conn: &Connection) -> Result<(), Error> {
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS schedule_category (
+            schedule_id INTEGER NOT NULL,
+            category_id INTEGER NOT NULL,
+            PRIMARY KEY (schedule_id, category_id),
+            FOREIGN KEY (schedule_id) REFERENCES schedules(id) ON DELETE CASCADE,
+            FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE CASCADE
+        )",
+        [],
+    )?;
+
+    conn.execute(
+        "INSERT OR IGNORE INTO schedule_category (schedule_id, category_id)
+         SELECT id, category_id FROM schedules WHERE category_id IS NOT NULL",
+        [],
+    )?;
+
+    conn.execute(
+        "UPDATE schedules SET category_id = NULL WHERE category_id IS NOT NULL",
+        [],
+    )?;
 
     Ok(())
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,30 +1,50 @@
 use chrono::Utc;
-use rusqlite::{params, Connection, Result};
+use rusqlite::{Connection, Result, Transaction, params};
 
-use crate::models::{DomainOverride, EmailConfig, GeneralConfig, ProcessorType, ReadItLaterArticle, Schedule};
+use crate::models::{
+    DomainOverride, EmailConfig, GeneralConfig, ProcessorType, ReadItLaterArticle, Schedule,
+};
 
-pub mod schema_init;
-mod migration;
 pub mod category_db;
 pub mod feed_db;
+mod migration;
+pub mod schema_init;
 
-pub fn add_schedule(conn: &Connection, cron_expression: &str, schedule_type: &str, category_id: Option<i64>) -> Result<()> {
-    conn.execute(
-        "INSERT INTO schedules (cron_expression, active, schedule_type, category_id, created_at) VALUES (?1, ?2, ?3, ?4, ?5)",
-        params![cron_expression, true, schedule_type, category_id, Utc::now().to_rfc3339()],
+pub fn add_schedule(
+    conn: &Connection,
+    cron_expression: &str,
+    schedule_type: &str,
+    timezone: &str,
+    category_ids: &[i64],
+    override_to_email: Option<&str>,
+    fetch_since_hours_override: Option<i32>,
+) -> Result<()> {
+    let tx = conn.unchecked_transaction()?;
+    tx.execute(
+        "INSERT INTO schedules (cron_expression, active, schedule_type, timezone, override_to_email, fetch_since_hours_override, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![cron_expression, true, schedule_type, timezone, override_to_email, fetch_since_hours_override, Utc::now().to_rfc3339()],
     )?;
+    let schedule_id = tx.last_insert_rowid();
+    save_schedule_categories(&tx, schedule_id, category_ids)?;
+    tx.commit()?;
     Ok(())
 }
 
 pub fn get_schedules(conn: &Connection) -> Result<Vec<Schedule>> {
-    let mut stmt = conn.prepare("SELECT id, cron_expression, active, schedule_type, category_id FROM schedules")?;
+    let mut stmt = conn.prepare(
+        "SELECT id, cron_expression, active, schedule_type, timezone, override_to_email, fetch_since_hours_override FROM schedules",
+    )?;
     let schedule_iter = stmt.query_map([], |row| {
+        let id: i64 = row.get(0)?;
         Ok(Schedule {
-            id: Some(row.get(0)?),
+            id: Some(id),
             cron_expression: row.get(1)?,
             active: row.get(2)?,
             schedule_type: row.get(3)?,
-            category_id: row.get(4)?,
+            timezone: row.get(4)?,
+            category_ids: get_schedule_category_ids(conn, id)?,
+            override_to_email: row.get(5)?,
+            fetch_since_hours_override: row.get(6)?,
         })
     })?;
 
@@ -35,8 +55,64 @@ pub fn get_schedules(conn: &Connection) -> Result<Vec<Schedule>> {
     Ok(schedules)
 }
 
+pub fn update_schedule(
+    conn: &Connection,
+    id: i64,
+    cron_expression: &str,
+    schedule_type: &str,
+    timezone: &str,
+    category_ids: &[i64],
+    override_to_email: Option<&str>,
+    fetch_since_hours_override: Option<i32>,
+) -> Result<()> {
+    let tx = conn.unchecked_transaction()?;
+    tx.execute(
+        "UPDATE schedules SET cron_expression = ?1, schedule_type = ?2, timezone = ?3, override_to_email = ?4, fetch_since_hours_override = ?5, category_id = NULL WHERE id = ?6",
+        params![cron_expression, schedule_type, timezone, override_to_email, fetch_since_hours_override, id],
+    )?;
+    save_schedule_categories(&tx, id, category_ids)?;
+    tx.commit()?;
+    Ok(())
+}
+
 pub fn delete_schedule(conn: &Connection, id: i64) -> Result<()> {
+    conn.execute(
+        "DELETE FROM schedule_category WHERE schedule_id = ?1",
+        params![id],
+    )?;
     conn.execute("DELETE FROM schedules WHERE id = ?1", params![id])?;
+    Ok(())
+}
+
+fn get_schedule_category_ids(conn: &Connection, schedule_id: i64) -> Result<Vec<i64>> {
+    let mut stmt = conn.prepare(
+        "SELECT category_id FROM schedule_category WHERE schedule_id = ?1 ORDER BY category_id ASC",
+    )?;
+    let rows = stmt.query_map(params![schedule_id], |row| row.get(0))?;
+
+    let mut category_ids = Vec::new();
+    for row in rows {
+        category_ids.push(row?);
+    }
+    Ok(category_ids)
+}
+
+fn save_schedule_categories(
+    tx: &Transaction<'_>,
+    schedule_id: i64,
+    category_ids: &[i64],
+) -> Result<()> {
+    tx.execute(
+        "DELETE FROM schedule_category WHERE schedule_id = ?1",
+        params![schedule_id],
+    )?;
+
+    let mut stmt =
+        tx.prepare("INSERT INTO schedule_category (schedule_id, category_id) VALUES (?1, ?2)")?;
+    for category_id in category_ids {
+        stmt.execute(params![schedule_id, category_id])?;
+    }
+
     Ok(())
 }
 
@@ -139,7 +215,7 @@ pub fn mark_articles_as_read(conn: &Connection, ids: &[i64]) -> Result<()> {
     for id in ids {
         stmt.execute(params![id])?;
     }
-    
+
     Ok(())
 }
 
@@ -173,7 +249,6 @@ pub fn update_general_config(conn: &Connection, config: &GeneralConfig) -> Resul
     )?;
     Ok(())
 }
-
 
 pub fn add_domain_override(
     conn: &Connection,
@@ -227,7 +302,8 @@ mod tests {
                 cover_date_color TEXT NOT NULL DEFAULT 'white'
             )",
             [],
-        ).unwrap();
+        )
+        .unwrap();
     }
 
     #[test]

--- a/src/db/schema_init.rs
+++ b/src/db/schema_init.rs
@@ -22,8 +22,11 @@ pub fn init_db(path: &str) -> rusqlite::Result<Connection> {
             cron_expression TEXT NOT NULL,
             active BOOLEAN NOT NULL DEFAULT 1,
             schedule_type TEXT NOT NULL DEFAULT 'rss',
+            timezone TEXT NOT NULL DEFAULT 'UTC',
             created_at TEXT NOT NULL,
-            category_id INTEGER
+            category_id INTEGER,
+            override_to_email TEXT,
+            fetch_since_hours_override INTEGER
         )",
         [],
     )?;
@@ -59,6 +62,17 @@ pub fn init_db(path: &str) -> rusqlite::Result<Connection> {
             feed_id INTEGER NOT NULL PRIMARY KEY,
             category_id INTEGER NOT NULL,
             FOREIGN KEY (feed_id) REFERENCES feeds(id) ON DELETE CASCADE,
+            FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE CASCADE
+        )",
+        [],
+    )?;
+
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS schedule_category (
+            schedule_id INTEGER NOT NULL,
+            category_id INTEGER NOT NULL,
+            PRIMARY KEY (schedule_id, category_id),
+            FOREIGN KEY (schedule_id) REFERENCES schedules(id) ON DELETE CASCADE,
             FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE CASCADE
         )",
         [],
@@ -122,6 +136,10 @@ pub fn init_db(path: &str) -> rusqlite::Result<Connection> {
     migration::migrate_constraint(&conn)?;
     migration::migrate_position(&conn)?;
     migration::migrate_feed_schedule(&conn)?;
+    migration::migrate_schedule_timezone(&conn)?;
+    migration::migrate_schedule_email_override(&conn)?;
+    migration::migrate_schedule_fetch_since_hours_override(&conn)?;
+    migration::migrate_schedule_categories(&conn)?;
     migration::migrate_general_config_cover_date(&conn)?;
     migration::migrate_email_config_smtp_username(&conn)?;
     Ok(conn)

--- a/src/email.rs
+++ b/src/email.rs
@@ -5,7 +5,7 @@ use lettre::message::{Attachment, MultiPart, SinglePart};
 use lettre::transport::smtp::authentication::Credentials;
 use lettre::AsyncSmtpTransport;
 use lettre::Tokio1Executor;
-use lettre::{AsyncTransport, Message};
+use lettre::{Address, AsyncTransport, Message};
 use std::env;
 use std::fs;
 use std::path::Path;
@@ -16,21 +16,52 @@ use rusqlite::Connection;
 use crate::db;
 use uuid::Uuid;
 
+pub fn parse_recipient_list(value: &str, field_name: &str) -> Result<Vec<Address>> {
+    let recipients = value
+        .split(',')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+        .map(|entry| entry.parse::<Address>())
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .with_context(|| format!("Invalid '{}' email", field_name))?;
+
+    if recipients.is_empty() {
+        anyhow::bail!("Missing '{}' email", field_name);
+    }
+
+    Ok(recipients)
+}
+
+pub fn normalize_recipient_list(value: &str, field_name: &str) -> Result<String> {
+    let recipients = parse_recipient_list(value, field_name)?;
+    Ok(recipients
+        .into_iter()
+        .map(|address| address.to_string())
+        .collect::<Vec<_>>()
+        .join(", "))
+}
+
 fn build_epub_message(config: &EmailConfig, filename: &str, filebody: Vec<u8>) -> Result<Message> {
     let content_type = ContentType::parse("application/epub+zip").unwrap();
     let attachment = Attachment::new(String::from(filename)).body(filebody, content_type);
 
-    Message::builder()
+    let from_address = config
+        .email_address
+        .parse()
+        .context("Invalid 'from' email")?;
+    let to_addresses = parse_recipient_list(&config.to_email, "to")?;
+
+    let mut builder = Message::builder()
         .date_now()
         .message_id(None)
         .user_agent(format!("RSSPub/{}", env!("CARGO_PKG_VERSION")))
-        .from(
-            config
-                .email_address
-                .parse()
-                .context("Invalid 'from' email")?,
-        )
-        .to(config.to_email.parse().context("Invalid 'to' email")?)
+        .from(from_address);
+
+    for address in to_addresses {
+        builder = builder.to(address.into());
+    }
+
+    builder
         .subject(format!("RSS Digest: {}", filename))
         .multipart(
             MultiPart::mixed()
@@ -123,7 +154,11 @@ pub async fn send_epub(config: &EmailConfig, epub_path: &Path) -> Result<()> {
     Ok(())
 }
 
-pub async fn check_and_send_email(db: Arc<Mutex<Connection>>, filename: &String) -> Result<()> {
+pub async fn check_and_send_email(
+    db: Arc<Mutex<Connection>>,
+    filename: &String,
+    override_to_email: Option<&str>,
+) -> Result<()> {
     let send_email = {
         let conn = db.lock().map_err(|_| anyhow::anyhow!("DB lock failed"))?;
         match db::get_email_config(&conn)? {
@@ -141,6 +176,10 @@ pub async fn check_and_send_email(db: Arc<Mutex<Connection>>, filename: &String)
         };
 
         if let Some(config) = config_opt {
+            let mut config = config;
+            if let Some(override_to_email) = override_to_email {
+                config.to_email = override_to_email.to_string();
+            }
             let epub_path = std::path::Path::new(crate::util::EPUB_OUTPUT_DIR).join(&filename);
             if let Err(e) = send_epub(&config, &epub_path).await {
                 error!("Failed to auto-send email: {}", e);
@@ -154,7 +193,7 @@ pub async fn check_and_send_email(db: Arc<Mutex<Connection>>, filename: &String)
 
 #[cfg(test)]
 mod tests {
-    use super::build_epub_message;
+    use super::{build_epub_message, normalize_recipient_list};
     use crate::models::EmailConfig;
 
     fn test_email_config() -> EmailConfig {
@@ -180,7 +219,10 @@ mod tests {
 
         let raw = String::from_utf8(email.formatted()).expect("message should serialize as utf-8");
 
-        assert!(raw.contains("Date:"), "raw message should include Date header");
+        assert!(
+            raw.contains("Date:"),
+            "raw message should include Date header"
+        );
         assert!(
             raw.contains("Message-ID:"),
             "raw message should include Message-ID header"
@@ -205,5 +247,27 @@ mod tests {
             raw.contains("application/epub+zip"),
             "raw message should include EPUB content type"
         );
+    }
+
+    #[test]
+    fn serializes_multiple_recipient_headers() {
+        let mut config = test_email_config();
+        config.to_email = "kindle@example.com, backup@example.com".to_string();
+
+        let email = build_epub_message(&config, "digest.epub", b"dummy epub bytes".to_vec())
+            .expect("message should build");
+
+        let raw = String::from_utf8(email.formatted()).expect("message should serialize as utf-8");
+
+        assert!(raw.contains("To: kindle@example.com, backup@example.com"));
+    }
+
+    #[test]
+    fn normalizes_recipient_lists() {
+        let normalized =
+            normalize_recipient_list(" kindle@example.com , , backup@example.com ", "to")
+                .expect("recipient list should normalize");
+
+        assert_eq!(normalized, "kindle@example.com, backup@example.com");
     }
 }

--- a/src/handlers/download_handler.rs
+++ b/src/handlers/download_handler.rs
@@ -71,11 +71,11 @@ pub async fn generate_epub_adhoc(
 
     tokio::spawn(async move {
         info!("Starting background EPUB generation...");
-        match processor::generate_and_save(feeds_to_fetch, &db_clone, util::EPUB_OUTPUT_DIR).await
+        match processor::generate_and_save(feeds_to_fetch, &db_clone, util::EPUB_OUTPUT_DIR, None).await
         {
             Ok(filename) => {
                 info!("Background generation completed successfully: {}", filename);
-                match  email::check_and_send_email(db_clone, &filename).await {
+                match  email::check_and_send_email(db_clone, &filename, None).await {
                     Ok(_ok) => {}
                     Err(_error) => {}
                 }
@@ -139,4 +139,3 @@ async fn download_latest_by_prefix(prefix: &str) -> Result<Response, (StatusCode
         .unwrap()
         .into_response())
 }
-

--- a/src/handlers/email_handler.rs
+++ b/src/handlers/email_handler.rs
@@ -2,8 +2,9 @@ use std::sync::Arc;
 use axum::extract::State;
 use axum::Json;
 use axum::http::StatusCode;
-use crate::db;
+use crate::{db, email};
 use crate::models::{AppState, EmailConfig};
+use lettre::Address;
 
 pub async fn get_email_config_handler(
     State(state): State<Arc<AppState>>,
@@ -41,6 +42,20 @@ pub async fn update_email_config_handler(
             payload.smtp_password = existing.smtp_password;
         }
     }
+
+    payload.email_address = payload.email_address.trim().to_string();
+    payload.to_email = payload.to_email.trim().to_string();
+
+    payload
+        .email_address
+        .parse::<Address>()
+        .map_err(|_| (StatusCode::BAD_REQUEST, "Invalid sender email".to_string()))?;
+    payload.to_email = email::normalize_recipient_list(&payload.to_email, "to").map_err(|_| {
+        (
+            StatusCode::BAD_REQUEST,
+            "Invalid recipient email list".to_string(),
+        )
+    })?;
 
     db::save_email_config(&db, &payload)
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;

--- a/src/handlers/read_it_later_handler.rs
+++ b/src/handlers/read_it_later_handler.rs
@@ -141,7 +141,7 @@ pub async fn deliver_read_it_later(
                     }
                 }
 
-                match email::check_and_send_email(db_clone, &filename).await {
+                match email::check_and_send_email(db_clone, &filename, None).await {
                     Ok(_ok) => {}
                     Err(_error) => {}
                 }

--- a/src/handlers/schedule_handler.rs
+++ b/src/handlers/schedule_handler.rs
@@ -5,7 +5,7 @@ use axum::http::StatusCode;
 use chrono_tz::Tz;
 use chrono::{Local, Timelike, Datelike};
 use tracing::{info, warn};
-use crate::{db, scheduler};
+use crate::{db, email, scheduler};
 use crate::models::{AddScheduleRequest, AppState, ScheduleResponse};
 
 pub async fn list_schedules(
@@ -34,7 +34,10 @@ pub async fn list_schedules(
                             active: s.active,
                             schedule_type: s.schedule_type,
                             cron_expression: s.cron_expression.clone(),
-                            category_id: s.category_id,
+                            timezone: s.timezone.clone(),
+                            category_ids: s.category_ids.clone(),
+                            override_to_email: s.override_to_email.clone(),
+                            fetch_since_hours_override: s.fetch_since_hours_override,
                         });
                         continue;
                     }
@@ -55,6 +58,84 @@ pub async fn add_schedule(
     State(state): State<Arc<AppState>>,
     Json(payload): Json<AddScheduleRequest>,
 ) -> Result<StatusCode, (StatusCode, String)> {
+    let cron_expression = build_cron_expression(&payload)?;
+    let override_to_email = validate_override_email(payload.override_to_email)?;
+    let fetch_since_hours_override = validate_fetch_since_hours_override(
+        &payload.schedule_type,
+        payload.fetch_since_hours_override,
+    )?;
+
+    info!(
+        "Converting {} {:02}:{:02} -> Cron {}",
+        payload.timezone, payload.hour, payload.minute, cron_expression
+    );
+
+    {
+        let db = state.db.lock().map_err(|_| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "DB lock failed".to_string(),
+            )
+        })?;
+        db::add_schedule(
+            &db,
+            &cron_expression,
+            &payload.schedule_type,
+            &payload.timezone,
+            &payload.category_ids,
+            override_to_email.as_deref(),
+            fetch_since_hours_override,
+        )
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    }
+
+    if let Some(value) = restart_schedule(state).await {
+        return value;
+    }
+
+    Ok(StatusCode::CREATED)
+}
+
+pub async fn update_schedule(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<i64>,
+    Json(payload): Json<AddScheduleRequest>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    let cron_expression = build_cron_expression(&payload)?;
+    let override_to_email = validate_override_email(payload.override_to_email)?;
+    let fetch_since_hours_override = validate_fetch_since_hours_override(
+        &payload.schedule_type,
+        payload.fetch_since_hours_override,
+    )?;
+
+    {
+        let db = state.db.lock().map_err(|_| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "DB lock failed".to_string(),
+            )
+        })?;
+        db::update_schedule(
+            &db,
+            id,
+            &cron_expression,
+            &payload.schedule_type,
+            &payload.timezone,
+            &payload.category_ids,
+            override_to_email.as_deref(),
+            fetch_since_hours_override,
+        )
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    }
+
+    if let Some(value) = restart_schedule(state).await {
+        return value;
+    }
+
+    Ok(StatusCode::OK)
+}
+
+fn build_cron_expression(payload: &AddScheduleRequest) -> Result<String, (StatusCode, String)> {
     let tz: Tz = payload
         .timezone
         .parse()
@@ -75,52 +156,94 @@ pub async fn add_schedule(
 
     let cron_expression = match payload.frequency.as_str() {
         "weekly" => {
-            let day = payload.day_of_week.ok_or((StatusCode::BAD_REQUEST, "Missing day of week".to_string()))?;
+            let day = payload
+                .day_of_week
+                .ok_or((StatusCode::BAD_REQUEST, "Missing day of week".to_string()))?;
             let mut current = target_time_in_tz;
-            let target_weekday = chrono::Weekday::try_from(day as u8).map_err(|_| (StatusCode::BAD_REQUEST, "Invalid day of week".to_string()))?;
+            let target_weekday = chrono::Weekday::try_from(day as u8)
+                .map_err(|_| (StatusCode::BAD_REQUEST, "Invalid day of week".to_string()))?;
             while current.weekday() != target_weekday {
                 current = current + chrono::Duration::days(1);
             }
             let target_in_server = current.with_timezone(&Local);
-            format!("0 {} {} * * {}", target_in_server.minute(), target_in_server.hour(), target_in_server.weekday().num_days_from_sunday())
-        },
+            format!(
+                "0 {} {} * * {}",
+                target_in_server.minute(),
+                target_in_server.hour(),
+                target_in_server.weekday().num_days_from_sunday()
+            )
+        }
         "monthly" => {
-            let day = payload.day_of_month.ok_or((StatusCode::BAD_REQUEST, "Missing day of month".to_string()))?;
+            let day = payload
+                .day_of_month
+                .ok_or((StatusCode::BAD_REQUEST, "Missing day of month".to_string()))?;
             let current = target_time_in_tz;
-             let candidate = current.date_naive().with_day(day);
+            let candidate = current.date_naive().with_day(day);
             if candidate.is_none() {
-                 return Err((StatusCode::BAD_REQUEST, "Invalid day of month for current month".to_string()));
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    "Invalid day of month for current month".to_string(),
+                ));
             }
-            let dt = candidate.unwrap().and_time(current.time()).and_local_timezone(tz).unwrap();
+            let dt = candidate
+                .unwrap()
+                .and_time(current.time())
+                .and_local_timezone(tz)
+                .unwrap();
             let target_in_server = dt.with_timezone(&Local);
-            format!("0 {} {} {} * *", target_in_server.minute(), target_in_server.hour(), target_in_server.day())
-        },
+            format!(
+                "0 {} {} {} * *",
+                target_in_server.minute(),
+                target_in_server.hour(),
+                target_in_server.day()
+            )
+        }
         _ => {
-             format!("0 {} {} * * *", server_minute, server_hour)
+            format!("0 {} {} * * *", server_minute, server_hour)
         }
     };
 
-    info!(
-        "Converting {} {:02}:{:02} -> Server {:02}:{:02} (Cron: {})",
-        payload.timezone, payload.hour, payload.minute, server_hour, server_minute, cron_expression
-    );
+    Ok(cron_expression)
+}
 
-    {
-        let db = state.db.lock().map_err(|_| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "DB lock failed".to_string(),
-            )
-        })?;
-        db::add_schedule(&db, &cron_expression, &payload.schedule_type, payload.category_id)
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+fn validate_fetch_since_hours_override(
+    schedule_type: &str,
+    fetch_since_hours_override: Option<i32>,
+) -> Result<Option<i32>, (StatusCode, String)> {
+    match fetch_since_hours_override {
+        Some(value) if value <= 0 => Err((
+            StatusCode::BAD_REQUEST,
+            "fetch_since_hours_override must be greater than 0".to_string(),
+        )),
+        Some(_) if schedule_type != "rss" => Err((
+            StatusCode::BAD_REQUEST,
+            "fetch_since_hours_override is only supported for rss schedules".to_string(),
+        )),
+        value => Ok(value),
     }
+}
 
-    if let Some(value) = restart_schedule(state).await {
-        return value;
+fn validate_override_email(
+    override_to_email: Option<String>,
+) -> Result<Option<String>, (StatusCode, String)> {
+    match override_to_email {
+        Some(email) => {
+            let trimmed = email.trim();
+            if trimmed.is_empty() {
+                Ok(None)
+            } else {
+                email::normalize_recipient_list(trimmed, "override")
+                    .map(Some)
+                    .map_err(|_| {
+                        (
+                            StatusCode::BAD_REQUEST,
+                            "Invalid override email list".to_string(),
+                        )
+                    })
+            }
+        }
+        None => Ok(None),
     }
-
-    Ok(StatusCode::CREATED)
 }
 
 pub async fn delete_schedule(
@@ -145,7 +268,9 @@ pub async fn delete_schedule(
     Ok(StatusCode::NO_CONTENT)
 }
 
-async fn restart_schedule(state: Arc<AppState>) -> Option<Result<StatusCode, (StatusCode, String)>> {
+async fn restart_schedule(
+    state: Arc<AppState>,
+) -> Option<Result<StatusCode, (StatusCode, String)>> {
     {
         let mut sched = state.scheduler.lock().await;
         if let Err(e) = sched.shutdown().await {

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -56,11 +56,22 @@ pub struct Schedule {
     pub active: bool,
     #[serde(default = "default_schedule_type")]
     pub schedule_type: String,
-    pub category_id: Option<i64>,
+    #[serde(default = "default_timezone")]
+    pub timezone: String,
+    #[serde(default)]
+    pub category_ids: Vec<i64>,
+    #[serde(default)]
+    pub override_to_email: Option<String>,
+    #[serde(default)]
+    pub fetch_since_hours_override: Option<i32>,
 }
 
 fn default_schedule_type() -> String {
     "rss".to_string()
+}
+
+fn default_timezone() -> String {
+    "UTC".to_string()
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -111,7 +122,6 @@ pub struct FeedPosition {
     pub position: i64,
 }
 
-
 #[derive(Serialize)]
 pub struct ScheduleResponse {
     pub id: i64,
@@ -119,13 +129,17 @@ pub struct ScheduleResponse {
     pub active: bool,
     pub schedule_type: String,
     pub cron_expression: String,
-    pub category_id: Option<i64>,
+    pub timezone: String,
+    pub category_ids: Vec<i64>,
+    pub override_to_email: Option<String>,
+    pub fetch_since_hours_override: Option<i32>,
 }
 
 #[derive(Deserialize)]
 pub struct AddScheduleRequest {
     pub hour: u32,
     pub minute: u32,
+    #[serde(default = "default_timezone")]
     pub timezone: String,
     #[serde(default = "default_schedule_type")]
     pub schedule_type: String,
@@ -133,7 +147,12 @@ pub struct AddScheduleRequest {
     pub frequency: String,
     pub day_of_week: Option<u32>,
     pub day_of_month: Option<u32>,
-    pub category_id: Option<i64>,
+    #[serde(default)]
+    pub category_ids: Vec<i64>,
+    #[serde(default)]
+    pub override_to_email: Option<String>,
+    #[serde(default)]
+    pub fetch_since_hours_override: Option<i32>,
 }
 
 fn default_frequency() -> String {
@@ -200,7 +219,7 @@ impl ProcessorType {
             _ => ProcessorType::Default,
         }
     }
-    
+
     pub fn to_i32(self) -> i32 {
         self as i32
     }

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -15,6 +15,7 @@ pub async fn generate_epub(
     feeds: Vec<Feed>,
     _db: &Arc<Mutex<Connection>>,
     output_path: &str,
+    fetch_since_hours_override: Option<i32>,
 ) -> Result<()> {
     info!("Fetching {} feeds...", feeds.len());
 
@@ -23,7 +24,8 @@ pub async fn generate_epub(
     let (since, image_timeout) = {
         let conn = _db.lock().map_err(|_| anyhow::anyhow!("DB lock failed"))?;
         let config = crate::db::get_general_config(&conn)?;
-        (Utc::now() - ChronoDuration::hours(config.fetch_since_hours as i64), config.image_timeout_seconds)
+        let fetch_since_hours = fetch_since_hours_override.unwrap_or(config.fetch_since_hours);
+        (Utc::now() - ChronoDuration::hours(fetch_since_hours as i64), config.image_timeout_seconds)
     };
     info!("Filtering items since: {}", since);
     let articles = feed::filter_items(fetched_feeds, errors, since).await;
@@ -76,11 +78,12 @@ pub async fn generate_and_save(
     feeds: Vec<Feed>,
     db: &Arc<Mutex<Connection>>,
     output_dir: &str,
+    fetch_since_hours_override: Option<i32>,
 ) -> Result<String> {
     let filename = format!("rss_digest_{}.epub", Utc::now().format("%Y%m%d_%H%M%S"));
     let filepath = format!("{}/{}", output_dir, filename);
 
-    generate_epub(feeds, db, &filepath).await?;
+    generate_epub(feeds, db, &filepath, fetch_since_hours_override).await?;
     Ok(filename)
 }
 

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -50,7 +50,7 @@ pub fn create_router(state: Arc<AppState>) -> Router {
             "/schedules",
             get(schedule_handler::list_schedules).post(schedule_handler::add_schedule),
         )
-        .route("/schedules/{id}", delete(schedule_handler::delete_schedule))
+        .route("/schedules/{id}", delete(schedule_handler::delete_schedule).put(schedule_handler::update_schedule))
         .route("/downloads", get(download_handler::list_downloads))
         .route("/cover", post(handlers::upload_cover))
         .route(

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,6 +1,7 @@
 use crate::{db, email, processor};
 use anyhow::Result;
 use rusqlite::Connection;
+use std::collections::HashSet;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -34,26 +35,36 @@ pub async fn init_scheduler(db_conn: Arc<Mutex<Connection>>) -> Result<JobSchedu
     for schedule in schedules {
         if schedule.active {
             let db_clone = db_conn.clone();
+            let job_type = schedule.schedule_type.clone();
+            let category_ids = schedule.category_ids.clone();
+            let override_to_email = schedule.override_to_email.clone();
+            let fetch_since_hours_override = schedule.fetch_since_hours_override;
             info!("Adding schedule: {}", schedule.cron_expression);
 
             match Job::new_async(schedule.cron_expression.as_str(), move |_uuid, _l| {
                 let db = db_clone.clone();
-                let job_type = schedule.schedule_type.clone();
+                let job_type = job_type.clone();
+                let category_ids = category_ids.clone();
+                let override_to_email = override_to_email.clone();
                 Box::pin(async move {
                     info!("Running scheduled generation for type: {}", job_type);
                     if job_type == RSS {
-                    let category = schedule.category_id.clone();
-                        if let Err(e) = run_scheduled_generation(db,category).await {
-                             error!("Scheduled generation (RSS) failed: {}", e);
+                        if let Err(e) = run_scheduled_generation(
+                            db,
+                            category_ids,
+                            override_to_email,
+                            fetch_since_hours_override,
+                        ).await
+                        {
+                            error!("Scheduled generation (RSS) failed: {}", e);
                         }
                     } else if job_type == READ_IT_LATER {
-                         if let Err(e) = run_read_it_later_generation(db).await {
-                             error!("Scheduled generation (Read It Later) failed: {}", e);
-                         }
+                        if let Err(e) = run_read_it_later_generation(db, override_to_email).await {
+                            error!("Scheduled generation (Read It Later) failed: {}", e);
+                        }
                     } else {
                         error!("Unknown schedule type: {}", job_type);
                     }
-
                 })
             }) {
                 Ok(job) => {
@@ -71,14 +82,32 @@ pub async fn init_scheduler(db_conn: Arc<Mutex<Connection>>) -> Result<JobSchedu
     Ok(sched)
 }
 
-async fn run_scheduled_generation(db: Arc<Mutex<Connection>>,category_id: Option<i64>) -> Result<()> {
+async fn run_scheduled_generation(
+    db: Arc<Mutex<Connection>>,
+    category_ids: Vec<i64>,
+    override_to_email: Option<String>,
+    fetch_since_hours_override: Option<i32>,
+) -> Result<()> {
     let feeds = {
         let conn = db.lock().map_err(|_| anyhow::anyhow!("DB lock failed"))?;
-        let stored_feeds = match category_id {
-            Some(id) => feed_db::get_feeds_by_category(&conn, id)?,
-            None => feed_db::get_feeds(&conn)?,
-        };
-        stored_feeds
+        if category_ids.is_empty() {
+            feed_db::get_feeds(&conn)?
+        } else {
+            let mut deduped_feeds = Vec::new();
+            let mut seen_feed_ids = HashSet::new();
+
+            for category_id in category_ids {
+                for feed in feed_db::get_feeds_by_category(&conn, category_id)? {
+                    let feed_id = feed.id.unwrap_or_default();
+                    if seen_feed_ids.insert(feed_id) {
+                        deduped_feeds.push(feed);
+                    }
+                }
+            }
+
+            deduped_feeds.sort_by_key(|feed| feed.position);
+            deduped_feeds
+        }
     };
 
     if feeds.is_empty() {
@@ -86,21 +115,28 @@ async fn run_scheduled_generation(db: Arc<Mutex<Connection>>,category_id: Option
         return Ok(());
     }
 
-    let filename = processor::generate_and_save(feeds, &db, crate::util::EPUB_OUTPUT_DIR).await?;
+    let filename = processor::generate_and_save(
+        feeds,
+        &db,
+        crate::util::EPUB_OUTPUT_DIR,
+        fetch_since_hours_override,
+    ).await?;
     info!("Scheduled generation completed: {}", filename);
-    email::check_and_send_email(db, &filename).await?;
+    email::check_and_send_email(db, &filename, override_to_email.as_deref()).await?;
 
     Ok(())
 }
 
-async fn run_read_it_later_generation(db: Arc<Mutex<Connection>>) -> Result<()> {
+async fn run_read_it_later_generation(
+    db: Arc<Mutex<Connection>>,
+    override_to_email: Option<String>,
+) -> Result<()> {
     let (articles, image_timeout) = {
-         let conn = db.lock().map_err(|_| anyhow::anyhow!("DB lock failed"))?;
-         let articles = db::get_read_it_later_articles(&conn, true)?;
-         let config = db::get_general_config(&conn)?;
+        let conn = db.lock().map_err(|_| anyhow::anyhow!("DB lock failed"))?;
+        let articles = db::get_read_it_later_articles(&conn, true)?;
+        let config = db::get_general_config(&conn)?;
 
-         
-         (articles, config.image_timeout_seconds)
+        (articles, config.image_timeout_seconds)
     };
 
     if articles.is_empty() {
@@ -109,9 +145,13 @@ async fn run_read_it_later_generation(db: Arc<Mutex<Connection>>) -> Result<()> 
     }
     let article_ids: Vec<i64> = articles.iter().filter_map(|a| a.id).collect();
 
-    let filename = processor::generate_read_it_later_epub(articles, crate::util::EPUB_OUTPUT_DIR, image_timeout).await?;
+    let filename = processor::generate_read_it_later_epub(
+        articles,
+        crate::util::EPUB_OUTPUT_DIR,
+        image_timeout,
+    )
+    .await?;
     info!("Read It Later generation completed: {}", filename);
-
 
     if !article_ids.is_empty() {
         match db.lock() {
@@ -126,7 +166,7 @@ async fn run_read_it_later_generation(db: Arc<Mutex<Connection>>) -> Result<()> 
         }
     }
 
-    email::check_and_send_email(db, &filename).await?;
+    email::check_and_send_email(db, &filename, override_to_email.as_deref()).await?;
     Ok(())
 }
 

--- a/ui/src/components/EmailConfigSection.svelte
+++ b/ui/src/components/EmailConfigSection.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { api } from "../lib/api";
     import { emailConfig, isAuthenticated, popup } from "../lib/store";
+    import type { EmailConfig } from "../lib/types";
 
     let smtp_host = "";
     let smtp_port: number | null = null;
@@ -14,13 +15,21 @@
     let statusColor = "";
     let isSaving = false;
 
+    function normalizeRecipientList(value: string): string {
+        return value
+            .split(",")
+            .map((e) => e.trim())
+            .filter((e) => e)
+            .join(", ");
+    }
+
     $: if ($isAuthenticated) {
         loadEmailConfig();
     }
 
     async function loadEmailConfig() {
         try {
-            const config = await api("/email-config");
+            const config = await api("/email-config") as EmailConfig | null;
             if (config) {
                 emailConfig.set(config);
                 smtp_host = config.smtp_host || "";
@@ -44,6 +53,8 @@
         isSaving = true;
         statusMsg = "Saving...";
         statusColor = "var(--text-secondary)";
+
+        to_email = normalizeRecipientList(to_email);
 
         try {
             await api("/email-config", "POST", {
@@ -156,9 +167,13 @@
                 <input
                     type="email"
                     bind:value={to_email}
-                    placeholder="To Email (Kindle)"
+                    placeholder="To Email(s), comma separated"
+                    multiple
                     required
                 />
+            </div>
+            <div style="margin: 0 0 15px; font-size: 0.85rem; color: var(--text-secondary);">
+                Multiple recipients can be separated with commas.
             </div>
             <button
                 type="submit"

--- a/ui/src/components/ScheduleForm.svelte
+++ b/ui/src/components/ScheduleForm.svelte
@@ -1,0 +1,241 @@
+<script lang="ts">
+    import { createEventDispatcher } from "svelte";
+    import type { Category, ScheduleDraft } from "../lib/types";
+
+    export let draft: ScheduleDraft;
+    export let categories: Category[] = [];
+    export let hours: string[] = [];
+    export let minutes: string[] = [];
+    export let timezones: string[] = [];
+    export let daysOfWeek: Array<{ val: string; label: string }> = [];
+    export let daysOfMonth: string[] = [];
+    export let submitLabel = "Save";
+    export let showCancel = false;
+    export let fetchWindowId = "schedule-fetch-window";
+
+    const dispatch = createEventDispatcher<{ submit: void; cancel: void }>();
+
+    function handleSubmit() {
+        dispatch("submit");
+    }
+
+    function handleCancel() {
+        dispatch("cancel");
+    }
+
+    let timezoneOptions: string[] = [];
+
+    $: timezoneOptions =
+        draft.timezone && !timezones.includes(draft.timezone)
+            ? [draft.timezone, ...timezones]
+            : timezones;
+</script>
+
+<form on:submit|preventDefault={handleSubmit} class="schedule-form">
+    <div class="form-grid schedule-form-grid">
+        <div class="input-group frequency-group">
+            <select bind:value={draft.frequency} class="modern-select" aria-label="Frequency">
+                <option value="daily">Daily</option>
+                <option value="weekly">Weekly</option>
+                <option value="monthly">Monthly</option>
+            </select>
+            {#if draft.frequency === "weekly"}
+                <select bind:value={draft.dayOfWeek} class="modern-select" aria-label="Day of Week">
+                    {#each daysOfWeek as d}
+                        <option value={d.val}>{d.label}</option>
+                    {/each}
+                </select>
+            {/if}
+            {#if draft.frequency === "monthly"}
+                <select bind:value={draft.dayOfMonth} class="modern-select" aria-label="Day of Month">
+                    {#each daysOfMonth as d}
+                        <option value={d}>{d}</option>
+                    {/each}
+                </select>
+            {/if}
+        </div>
+
+        <div class="input-group time-group">
+            <select bind:value={draft.hour} required class="modern-select time-select">
+                <option value="" disabled>HH</option>
+                {#each hours as h}
+                    <option value={h}>{h}</option>
+                {/each}
+            </select>
+            <span class="time-separator">:</span>
+            <select bind:value={draft.minute} required class="modern-select time-select">
+                <option value="" disabled>MM</option>
+                {#each minutes as m}
+                    <option value={m}>{m}</option>
+                {/each}
+            </select>
+        </div>
+
+        <select bind:value={draft.timezone} class="modern-select timezone-select" aria-label="Timezone">
+            {#each timezoneOptions as tz}
+                <option value={tz}>{tz}</option>
+            {/each}
+        </select>
+
+        <select bind:value={draft.scheduleType} class="modern-select type-select" aria-label="Schedule Type">
+            <option value="rss">RSS Generator</option>
+            <option value="read_it_later">Read It Later</option>
+        </select>
+
+        <input
+            bind:value={draft.overrideToEmail}
+            type="email"
+            multiple
+            class="modern-select email-input"
+            placeholder="Recipient email(s) [optional]"
+        />
+    </div>
+
+    <div class="selection-hint">Multiple recipients can be separated with commas.</div>
+
+    {#if draft.scheduleType === "rss"}
+        <div class="schedule-details-grid">
+            <div class="category-picker">
+                <div class="category-picker-label">Categories</div>
+                <div class="category-options">
+                    {#each categories as cat (cat.id)}
+                        <label class="category-option">
+                            <input type="checkbox" bind:group={draft.categoryIds} value={String(cat.id)} />
+                            <span>{cat.name}</span>
+                        </label>
+                    {/each}
+                </div>
+                {#if draft.categoryIds.length === 0}
+                    <div class="selection-hint">No selection means all categories.</div>
+                {/if}
+            </div>
+
+            <div class="field-stack compact-field">
+                <label for={fetchWindowId}>Fetch Window Override</label>
+                <input
+                    id={fetchWindowId}
+                    bind:value={draft.fetchSinceHoursOverride}
+                    type="number"
+                    min="1"
+                    step="1"
+                    class="modern-select"
+                    placeholder="Hours [optional]"
+                />
+            </div>
+        </div>
+    {/if}
+
+    <div class="form-actions" class:with-cancel={showCancel}>
+        <button type="submit" class="add-btn-modern">{submitLabel}</button>
+        {#if showCancel}
+            <button type="button" class="secondary-btn" on:click={handleCancel}>Cancel</button>
+        {/if}
+    </div>
+</form>
+
+<style>
+    .schedule-form {
+        display: grid;
+        gap: 1rem;
+    }
+
+    .schedule-form-grid {
+        align-items: end;
+        gap: 0.85rem;
+    }
+
+    .email-input {
+        grid-column: span 2;
+    }
+
+    .schedule-details-grid {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) minmax(180px, 220px);
+        gap: 1rem;
+        align-items: start;
+    }
+
+    .field-stack {
+        display: grid;
+        gap: 0.4rem;
+    }
+
+    .field-stack label {
+        font-size: 0.85rem;
+        font-weight: 600;
+        opacity: 0.9;
+    }
+
+    .compact-field {
+        align-content: start;
+    }
+
+    .category-picker {
+        display: grid;
+        gap: 0.45rem;
+    }
+
+    .category-picker-label {
+        font-size: 0.85rem;
+        font-weight: 600;
+        opacity: 0.95;
+    }
+
+    .category-options {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.4rem;
+    }
+
+    .category-option {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.3rem;
+        padding: 0.28rem 0.55rem;
+        font-size: 0.92rem;
+        background: rgba(255, 255, 255, 0.02);
+        border: 1px solid rgba(255, 255, 255, 0.15);
+        border-radius: 999px;
+    }
+
+    .category-option input {
+        width: 0.8rem;
+        height: 0.8rem;
+        margin: 0;
+    }
+
+    .selection-hint {
+        font-size: 0.8rem;
+        opacity: 0.72;
+        line-height: 1.35;
+    }
+
+    .form-actions {
+        display: flex;
+        justify-content: flex-start;
+        margin-top: 0.25rem;
+    }
+
+    .form-actions.with-cancel {
+        gap: 0.75rem;
+    }
+
+    .secondary-btn {
+        border: 1px solid rgba(255, 255, 255, 0.15);
+        background: transparent;
+        color: inherit;
+        border-radius: 8px;
+        padding: 0.45rem 0.75rem;
+        cursor: pointer;
+    }
+
+    @media (max-width: 700px) {
+        .email-input {
+            grid-column: 1 / -1;
+        }
+
+        .schedule-details-grid {
+            grid-template-columns: 1fr;
+        }
+    }
+</style>

--- a/ui/src/components/SchedulesSection.svelte
+++ b/ui/src/components/SchedulesSection.svelte
@@ -2,22 +2,17 @@
     import { onMount } from "svelte";
     import { api } from "../lib/api";
     import { schedules, categories, isAuthenticated, popup } from "../lib/store";
-    let hour = "";
-    let minute = "";
-    let scheduleType = "rss";
-    let frequency = "daily";
-    let dayOfWeek = "0";
-    let dayOfMonth = "1";
-    let timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    let categoryId = "";
+    import type { Schedule, ScheduleDraft, ScheduleFrequency, ScheduleType } from "../lib/types";
+    import ScheduleForm from "./ScheduleForm.svelte";
 
-    const hours = Array.from({ length: 24 }, (_, i) =>
-        i.toString().padStart(2, "0"),
-    );
-    const minutes = Array.from({ length: 12 }, (_, i) =>
-        (i * 5).toString().padStart(2, "0"),
-    );
+    const hours = Array.from({ length: 24 }, (_, i) => i.toString().padStart(2, "0"));
+    const minutes = Array.from({ length: 12 }, (_, i) => (i * 5).toString().padStart(2, "0"));
     const timezones = Intl.supportedValuesOf("timeZone");
+    const localTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+    let createDraft = emptyDraft();
+    let editingId: number | null = null;
+    let editDraft = emptyDraft();
 
     const daysOfWeek = [
         { val: "0", label: "Monday" },
@@ -28,13 +23,12 @@
         { val: "5", label: "Saturday" },
         { val: "6", label: "Sunday" },
     ];
-    
+
     const daysOfMonth = Array.from({ length: 31 }, (_, i) => (i + 1).toString());
 
     onMount(() => {
-        const localTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
-        if (timezones.includes(localTz)) {
-            timezone = localTz;
+        if ($isAuthenticated) {
+            loadSchedules();
         }
     });
 
@@ -42,46 +36,126 @@
         loadSchedules();
     }
 
+    function emptyDraft(): ScheduleDraft {
+        return {
+            hour: "",
+            minute: "",
+            scheduleType: "rss",
+            frequency: "daily",
+            dayOfWeek: "0",
+            dayOfMonth: "1",
+            timezone: timezones.includes(localTimezone) ? localTimezone : "UTC",
+            categoryIds: [],
+            overrideToEmail: "",
+            fetchSinceHoursOverride: "",
+        };
+    }
+
     async function loadSchedules() {
         try {
-            const data = await api("/schedules");
+            const data = await api("/schedules") as Schedule[] | null;
             if (data) schedules.set(data);
         } catch (e) {
             console.error(e);
         }
     }
 
-    async function addSchedule() {
-        if (!hour || !minute || !timezone || !scheduleType) {
+    function normalizeOptionalText(value: string | number | null | undefined): string {
+        if (value == null) return "";
+        return String(value).trim();
+    }
+
+    function normalizeRecipientList(value: string): string {
+        return value
+            .split(",")
+            .map((e) => e.trim())
+            .filter((e) => e)
+            .join(", ");
+    }
+
+    function normalizeScheduleType(value: string): ScheduleType {
+        return value === "read_it_later" ? "read_it_later" : "rss";
+    }
+
+    function inferDraftFrequency(parts: string[]): ScheduleFrequency {
+        if (parts[3] !== "*" && parts[5] === "*") return "monthly";
+        if (parts[3] === "*" && parts[5] !== "*") return "weekly";
+        return "daily";
+    }
+
+    function toPayload(draft: ScheduleDraft) {
+        const trimmedFetchSinceHoursOverride = normalizeOptionalText(draft.fetchSinceHoursOverride);
+        const payload: any = {
+            hour: parseInt(draft.hour, 10),
+            minute: parseInt(draft.minute, 10),
+            timezone: draft.timezone,
+            schedule_type: draft.scheduleType,
+            frequency: draft.frequency,
+            category_ids:
+                draft.scheduleType === "rss"
+                    ? draft.categoryIds.map((id) => parseInt(id, 10)).filter((id) => !Number.isNaN(id))
+                    : [],
+            override_to_email: normalizeRecipientList(draft.overrideToEmail) || null,
+            fetch_since_hours_override:
+                draft.scheduleType === "rss" && trimmedFetchSinceHoursOverride
+                    ? parseInt(trimmedFetchSinceHoursOverride, 10)
+                    : null,
+        };
+
+        if (draft.frequency === "weekly") {
+            payload.day_of_week = parseInt(draft.dayOfWeek, 10);
+        } else if (draft.frequency === "monthly") {
+            payload.day_of_month = parseInt(draft.dayOfMonth, 10);
+        }
+
+        return payload;
+    }
+
+    function validateDraft(draft: ScheduleDraft) {
+        if (!draft.hour || !draft.minute || !draft.timezone || !draft.scheduleType) {
             popup.set({
                 visible: true,
                 title: "Missing Information",
-                message: "Please select Time, Timezone, and Type.",
+                message: "Please select a time, timezone, and schedule type.",
                 isError: true,
             });
-            return;
+            return false;
         }
 
-        const payload: any = {
-            hour: parseInt(hour, 10),
-            minute: parseInt(minute, 10),
-            timezone,
-            schedule_type: scheduleType,
-            frequency,
-        };
-        if (categoryId !== "") {
-            payload.category_id = parseInt(categoryId, 10);
+        const trimmedFetchSinceHoursOverride = normalizeOptionalText(draft.fetchSinceHoursOverride);
+        if (draft.scheduleType === "rss" && trimmedFetchSinceHoursOverride) {
+            const value = Number(trimmedFetchSinceHoursOverride);
+            if (!Number.isInteger(value) || value <= 0) {
+                popup.set({
+                    visible: true,
+                    title: "Invalid Fetch Window",
+                    message: "Fetch window override must be a positive whole number.",
+                    isError: true,
+                });
+                return false;
+            }
         }
-        
-        if (frequency === "weekly") {
-            payload.day_of_week = parseInt(dayOfWeek, 10);
-        } else if (frequency === "monthly") {
-            payload.day_of_month = parseInt(dayOfMonth, 10);
+
+        if (!draft.timezone) {
+            popup.set({
+                visible: true,
+                title: "Invalid Timezone",
+                message: "Please select a valid timezone.",
+                isError: true,
+            });
+            return false;
         }
+
+        return true;
+    }
+
+    async function addSchedule() {
+        if (!validateDraft(createDraft)) return;
 
         try {
-            await api("/schedules", "POST", payload);
-            loadSchedules();
+            await api("/schedules", "POST", toPayload(createDraft));
+            createDraft = emptyDraft();
+            await loadSchedules();
         } catch (e: any) {
             popup.set({
                 visible: true,
@@ -90,6 +164,109 @@
                 isError: true,
             });
         }
+    }
+
+    function startEdit(schedule: Schedule) {
+        editingId = schedule.id;
+        editDraft = draftFromSchedule(schedule);
+    }
+
+    function cancelEdit() {
+        editingId = null;
+        editDraft = emptyDraft();
+    }
+
+    async function saveEdit(id: number) {
+        if (!validateDraft(editDraft)) return;
+
+        try {
+            await api(`/schedules/${id}`, "PUT", toPayload(editDraft));
+            cancelEdit();
+            await loadSchedules();
+        } catch (e: any) {
+            popup.set({
+                visible: true,
+                title: "Error",
+                message: e.message,
+                isError: true,
+            });
+        }
+    }
+
+    function draftFromSchedule(schedule: Schedule): ScheduleDraft {
+        const date = schedule.time ? new Date(schedule.time) : null;
+        const parts = (schedule.cron_expression || "").split(" ");
+        const frequency = inferDraftFrequency(parts);
+        const timezone = schedule.timezone || "UTC";
+        const zonedDateParts = date ? getDatePartsInTimezone(date, timezone) : null;
+
+        return {
+            hour: zonedDateParts?.hour || parts[2]?.padStart(2, "0") || "",
+            minute: zonedDateParts?.minute || parts[1]?.padStart(2, "0") || "",
+            scheduleType: normalizeScheduleType(schedule.schedule_type || "rss"),
+            frequency,
+            dayOfWeek:
+                frequency === "weekly"
+                    ? dayOfWeekFromSchedule(zonedDateParts, parts)
+                    : "0",
+            dayOfMonth:
+                frequency === "monthly"
+                    ? dayOfMonthFromSchedule(zonedDateParts, parts)
+                    : "1",
+            timezone,
+            categoryIds: schedule.category_ids.map((id) => String(id)),
+            overrideToEmail: schedule.override_to_email || "",
+            fetchSinceHoursOverride: schedule.fetch_since_hours_override ?? "",
+        };
+    }
+
+    function getDatePartsInTimezone(date: Date, timezone: string) {
+        const formatter = new Intl.DateTimeFormat("en-CA", {
+            timeZone: timezone,
+            hour: "2-digit",
+            minute: "2-digit",
+            weekday: "short",
+            day: "2-digit",
+            hour12: false,
+        });
+
+        const partMap = Object.fromEntries(
+            formatter
+                .formatToParts(date)
+                .filter((part) => part.type !== "literal")
+                .map((part) => [part.type, part.value]),
+        );
+
+        return {
+            hour: partMap.hour,
+            minute: partMap.minute,
+            weekday: partMap.weekday,
+            day: partMap.day,
+        };
+    }
+
+    function dayOfWeekFromSchedule(
+        zonedDateParts: { weekday?: string } | null,
+        parts: string[],
+    ) {
+        if (zonedDateParts?.weekday) {
+            const weekdays = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+            const weekdayIndex = weekdays.indexOf(zonedDateParts.weekday);
+            if (weekdayIndex >= 0) {
+                return weekdayIndex.toString();
+            }
+        }
+
+        const cronDay = parseInt(parts[5] || "0", 10);
+        return Number.isNaN(cronDay) ? "0" : ((cronDay + 6) % 7).toString();
+    }
+
+    function dayOfMonthFromSchedule(zonedDateParts: { day?: string } | null, parts: string[]) {
+        if (zonedDateParts?.day) {
+            return String(parseInt(zonedDateParts.day, 10));
+        }
+
+        return parts[3] || "1";
     }
 
     function deleteSchedule(id: number) {
@@ -102,7 +279,10 @@
             onConfirm: async () => {
                 try {
                     await api(`/schedules/${id}`, "DELETE");
-                    loadSchedules();
+                    if (editingId === id) {
+                        cancelEdit();
+                    }
+                    await loadSchedules();
                 } catch (e: any) {
                     popup.set({
                         visible: true,
@@ -116,16 +296,14 @@
         });
     }
 
-    function formatCron(schedule: any) {
+    function formatCron(schedule: Schedule) {
         const cron = schedule.cron_expression;
         if (!cron) return "Unknown";
-        
+
         let localTimeStr = "";
-        let dayShift = 0;
-        
         if (schedule.time) {
             const date = new Date(schedule.time);
-            localTimeStr = date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+            localTimeStr = date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
         }
 
         const parts = cron.split(" ");
@@ -135,118 +313,198 @@
         const hour = parts[2].padStart(2, "0");
         const dom = parts[3];
         const dow = parts[5];
-        
         const displayTime = localTimeStr || `${hour}:${min}`;
-        
+
         if (dom === "*" && dow === "*") {
             return `Daily at ${displayTime}`;
-        } else if (dom === "*" && dow !== "*") {
-             const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-             let d = parseInt(dow, 10);
-             
-             if (!isNaN(d)) {
-                 d = d + dayShift;
-                 if (d < 0) d += 7;
-                 d = d % 7;
-             }
-             
-             const dayName = !isNaN(d) && days[d] ? days[d] : dow;
-             return `Weekly on ${dayName} at ${displayTime}`;
-        } else if (dom !== "*" && dow === "*") {
-             return `Monthly on day ${dom} at ${displayTime}`;
         }
+
+        if (dom === "*" && dow !== "*") {
+            const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+            const dayName = days[parseInt(dow, 10)] || dow;
+            return `Weekly on ${dayName} at ${displayTime}`;
+        }
+
+        if (dom !== "*" && dow === "*") {
+            return `Monthly on day ${dom} at ${displayTime}`;
+        }
+
         return cron;
+    }
+
+    function categoryNames(categoryIds: number[]) {
+        if (!categoryIds?.length) return ["All categories"];
+        return categoryIds.map((id) => ($categories.find((c) => c.id === id) || {}).name || String(id));
     }
 </script>
 
 <section id="schedules-section" class="card">
     <div class="card-header">
-        <img
-            src="/icons/clock.svg"
-            alt="Schedule Icon"
-            width="20"
-            height="20"
-        />
+        <img src="/icons/clock.svg" alt="Schedule Icon" width="20" height="20" />
         <h2>Schedules</h2>
     </div>
+
     <ul id="schedules-list" class="item-list">
         {#each $schedules as schedule (schedule.id)}
-            <li>
-                <div class="schedule-info">
-                    <span class="schedule-time">{formatCron(schedule)}</span>
-                    <span class="schedule-type-badge">{schedule.schedule_type || 'rss'}</span>
-                    {#if schedule.category_id}
-                        <span class="schedule-category-badge" style="font-size: 0.8rem; background: #607d8b; color: #fff; padding: 2px 6px; border-radius: 4px; margin-left: 5px;">
-                            Category: {($categories.find(c => c.id === schedule.category_id) || {}).name || schedule.category_id}
-                        </span>
-                    {/if}
-                </div>
-                <button
-                    on:click={() => deleteSchedule(schedule.id)}
-                    class="delete-btn">×</button
-                >
+            <li class="schedule-item">
+                {#if editingId === schedule.id}
+                    <div class="schedule-edit">
+                        <ScheduleForm
+                            draft={editDraft}
+                            categories={$categories}
+                            {hours}
+                            {minutes}
+                            {timezones}
+                            {daysOfWeek}
+                            {daysOfMonth}
+                            submitLabel="Save"
+                            showCancel={true}
+                            fetchWindowId={"edit-fetch-window-" + schedule.id}
+                            on:submit={() => saveEdit(schedule.id)}
+                            on:cancel={cancelEdit}
+                        />
+                    </div>
+                {:else}
+                    <div class="schedule-info">
+                        <span class="schedule-time">{formatCron(schedule)}</span>
+                        <div class="schedule-meta-row">
+                            <span class="schedule-type-badge">{schedule.schedule_type || "rss"}</span>
+                            {#if (schedule.schedule_type || "rss") === "rss"}
+                                {#each categoryNames(schedule.category_ids || []) as categoryName}
+                                    <span class="schedule-category-badge">{categoryName}</span>
+                                {/each}
+                                {#if schedule.fetch_since_hours_override != null}
+                                    <span class="schedule-fetch-badge">{schedule.fetch_since_hours_override}h window</span>
+                                {/if}
+                            {/if}
+                            {#if schedule.override_to_email}
+                                <span class="schedule-email-badge">{schedule.override_to_email}</span>
+                            {/if}
+                        </div>
+                    </div>
+                    <div class="schedule-actions">
+                        <button on:click={() => startEdit(schedule)} class="secondary-btn">Edit</button>
+                        <button on:click={() => deleteSchedule(schedule.id)} class="delete-btn">×</button>
+                    </div>
+                {/if}
             </li>
         {/each}
     </ul>
-    <form on:submit|preventDefault={addSchedule} id="add-schedule-form" class="modern-form">
-        <div class="form-grid">
-            <div class="input-group frequency-group">
-                <select bind:value={frequency} class="modern-select" aria-label="Frequency">
-                    <option value="daily">Daily</option>
-                    <option value="weekly">Weekly</option>
-                    <option value="monthly">Monthly</option>
-                </select>
-                {#if frequency === "weekly"}
-                    <select bind:value={dayOfWeek} class="modern-select" aria-label="Day of Week">
-                        {#each daysOfWeek as d}
-                            <option value={d.val}>{d.label}</option>
-                        {/each}
-                    </select>
-                {/if}
-                {#if frequency === "monthly"}
-                    <select bind:value={dayOfMonth} class="modern-select" aria-label="Day of Month">
-                        {#each daysOfMonth as d}
-                            <option value={d}>{d}</option>
-                        {/each}
-                    </select>
-                {/if}
-            </div>
 
-            <div class="input-group time-group">
-                <select bind:value={hour} required class="modern-select time-select">
-                    <option value="" disabled selected>HH</option>
-                    {#each hours as h}
-                        <option value={h}>{h}</option>
-                    {/each}
-                </select>
-                <span class="time-separator">:</span>
-                <select bind:value={minute} required class="modern-select time-select">
-                    <option value="" disabled selected>MM</option>
-                    {#each minutes as m}
-                        <option value={m}>{m}</option>
-                    {/each}
-                </select>
-            </div>
-
-            <select bind:value={timezone} id="timezone-select" required class="modern-select timezone-select">
-                {#each timezones as tz}
-                    <option value={tz}>{tz}</option>
-                {/each}
-            </select>
-
-            <select bind:value={scheduleType} required class="modern-select type-select">
-                <option value="rss">RSS Generator</option>
-                <option value="read_it_later">Read It Later</option>
-            </select>
-
-            <select bind:value={categoryId} class="modern-select">
-                <option value="">All Categories</option>
-                {#each $categories as cat (cat.id)}
-                    <option value={cat.id}>{cat.name}</option>
-                {/each}
-            </select>
-            
-            <button type="submit" class="add-btn-modern">Add Schedule</button>
-        </div>
-    </form>
+    <div id="add-schedule-form" class="modern-form">
+        <ScheduleForm
+            draft={createDraft}
+            categories={$categories}
+            {hours}
+            {minutes}
+            {timezones}
+            {daysOfWeek}
+            {daysOfMonth}
+            submitLabel="Add Schedule"
+            fetchWindowId="create-fetch-window"
+            on:submit={addSchedule}
+        />
+    </div>
 </section>
+
+<style>
+    .schedule-item {
+        display: flex;
+        justify-content: space-between;
+        gap: 1.25rem;
+        align-items: center;
+    }
+
+    .schedule-info,
+    .schedule-actions,
+    .schedule-edit {
+        display: flex;
+        gap: 0.75rem;
+        align-items: center;
+        flex-wrap: wrap;
+    }
+
+    .schedule-info {
+        flex: 1;
+        min-width: 0;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.6rem;
+    }
+
+    .schedule-time {
+        font-size: 1.05rem;
+        line-height: 1.3;
+    }
+
+    .schedule-meta-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.45rem;
+        align-items: center;
+    }
+
+    .schedule-actions {
+        flex-shrink: 0;
+        align-self: flex-start;
+    }
+
+    .schedule-edit {
+        width: 100%;
+        flex-direction: column;
+        align-items: stretch;
+        gap: 1rem;
+    }
+
+    .schedule-category-badge,
+    .schedule-fetch-badge,
+    .schedule-email-badge,
+    .schedule-type-badge {
+        font-size: 0.8rem;
+        color: #fff;
+        padding: 0.28rem 0.6rem;
+        border-radius: 999px;
+        line-height: 1;
+    }
+
+    .schedule-category-badge {
+        background: #607d8b;
+    }
+
+    .schedule-type-badge {
+        background: rgba(255, 255, 255, 0.08);
+        color: rgba(255, 255, 255, 0.8);
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+    }
+
+    .schedule-email-badge {
+        background: #7b5cff;
+    }
+
+    .schedule-fetch-badge {
+        background: #2f855a;
+    }
+
+    .secondary-btn {
+        border: 1px solid rgba(255, 255, 255, 0.15);
+        background: transparent;
+        color: inherit;
+        border-radius: 8px;
+        padding: 0.45rem 0.75rem;
+        cursor: pointer;
+    }
+
+    @media (max-width: 700px) {
+        .schedule-item {
+            flex-direction: column;
+            align-items: stretch;
+        }
+
+        .schedule-actions {
+            width: 100%;
+            justify-content: flex-end;
+            align-self: auto;
+        }
+    }
+</style>

--- a/ui/src/lib/store.ts
+++ b/ui/src/lib/store.ts
@@ -1,4 +1,5 @@
 import { writable } from "svelte/store";
+import type { Category, EmailConfig, Schedule } from "./types";
 
 export const authHeader = writable<string | null>(
   localStorage.getItem("rsspub_auth"),
@@ -18,10 +19,10 @@ authHeader.subscribe((value) => {
 });
 
 export const feeds = writable<any[]>([]);
-export const categories = writable<any[]>([]);
-export const schedules = writable<any[]>([]);
+export const categories = writable<Category[]>([]);
+export const schedules = writable<Schedule[]>([]);
 export const downloads = writable<string[]>([]);
-export const emailConfig = writable<any>(null);
+export const emailConfig = writable<EmailConfig | null>(null);
 
 export const isLoginVisible = writable<boolean>(false);
 export const popup = writable<{

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1,0 +1,43 @@
+export type ScheduleType = "rss" | "read_it_later";
+
+export type ScheduleFrequency = "daily" | "weekly" | "monthly";
+
+export type Category = {
+    id: number;
+    name: string;
+};
+
+export type EmailConfig = {
+    smtp_host: string;
+    smtp_port: number;
+    smtp_password: string;
+    smtp_username: string;
+    email_address: string;
+    to_email: string;
+    enable_auto_send: boolean;
+};
+
+export type Schedule = {
+    id: number;
+    time: string;
+    active: boolean;
+    schedule_type: ScheduleType | string;
+    cron_expression: string;
+    timezone: string;
+    category_ids: number[];
+    override_to_email: string | null;
+    fetch_since_hours_override: number | null;
+};
+
+export type ScheduleDraft = {
+    hour: string;
+    minute: string;
+    scheduleType: ScheduleType;
+    frequency: ScheduleFrequency;
+    dayOfWeek: string;
+    dayOfMonth: string;
+    timezone: string;
+    categoryIds: string[];
+    overrideToEmail: string;
+    fetchSinceHoursOverride: number | "";
+};


### PR DESCRIPTION
I would like to suggest a new feature with this PR. The use case is to have different schedules for different categories.

* Adds support for filtering schedules by multiple feed categories and optional email and per-schedule fetch window overrides
* Extends email delivery to support multiple recipients

<img width="1025" height="742" alt="image" src="https://github.com/user-attachments/assets/f418026f-4a95-4a90-8746-c332b852a58d" />
